### PR TITLE
AtCoder (beta) support.

### DIFF
--- a/atcoder.js
+++ b/atcoder.js
@@ -27,12 +27,12 @@ function fetch_atcoder_result(base_url, ids) {
             } else {
                 var score = obj["Score"];
                 var verdict = /title=\"([^\"]*)\"/g.exec(obj["Html"])[1];
-                var time = /[0-9]* ms/g.exec(obj["Html"])[0];
-                var mem = /[0-9]* KB/g.exec(obj["Html"])[0];
+                var time = /[0-9]* ms/g.exec(obj["Html"]);
+                var mem = /[0-9]* KB/g.exec(obj["Html"]);
                 browser.runtime.sendMessage({
                     verdict: verdict,
-                    time: time,
-                    mem: mem,
+                    time: time ? time[0] : undefined,
+                    mem: mem ? mem[0] : undefined,
                     id: id,
                     score: score
                 });

--- a/atcoder.js
+++ b/atcoder.js
@@ -9,7 +9,7 @@ var submissions = [].slice.call(document.getElementsByClassName("waiting-judge")
 
 function fetch_atcoder_result(base_url, ids) {
     var xhr = new XMLHttpRequest();
-    var url_param = [].slice.call(ids).map(it => "sids[]=" + ids).join("&")
+    var url_param = [].slice.call(ids).map(it => "sids[]=" + it).join("&")
     var ids_to_refresh = []
     var url = base_url + "/status/json?" + url_param;
     xhr.open("GET", url, true);

--- a/atcoder.js
+++ b/atcoder.js
@@ -1,0 +1,52 @@
+window.browser = (function () {
+    return window.msBrowser ||
+      window.browser ||
+      window.chrome;
+  })();
+
+var url = window.location.href;
+var submissions = [].slice.call(document.getElementsByClassName("waiting-judge")).map(it => it.getAttribute("data-id"));
+
+function fetch_atcoder_result(base_url, ids) {
+    var xhr = new XMLHttpRequest();
+    var url_param = [].slice.call(ids).map(it => "sids[]=" + ids).join("&")
+    var ids_to_refresh = []
+    var url = base_url + "/status/json?" + url_param;
+    xhr.open("GET", url, true);
+    xhr.send();
+    xhr.onload = function(e) {
+        var result = JSON.parse(xhr.response);
+        ids.forEach(function(id) {
+            var obj = result[id];
+            if (obj["Html"].includes("waiting-judge")) {
+                /* On AtCoder, a solution can be marked as judging and WA,TLE,MLE,RE at the same time. 
+                 * This means that the solution is still being run on more testcases. When this happens,
+                 * the running time, consumed memory and score is not yet available. Since AtCoder has 
+                 * partial scores, we do not report the verdict just yet. */
+                ids_to_refresh.push(id);        
+            } else {
+                var score = obj["Score"];
+                var verdict = /title=\"([^\"]*)\"/g.exec(obj["Html"])[1];
+                var time = /[0-9]* ms/g.exec(obj["Html"])[0];
+                var mem = /[0-9]* KB/g.exec(obj["Html"])[0];
+                browser.runtime.sendMessage({
+                    verdict: verdict,
+                    time: time,
+                    mem: mem,
+                    id: id,
+                    score: score
+                });
+            }
+        });
+        
+        if (ids_to_refresh.length > 0) {
+            setTimeout(function() {
+                fetch_atcoder_result(base_url, ids_to_refresh);
+            },500);
+        }
+    };
+}
+
+if (submissions.length > 0) {
+    fetch_atcoder_result(url, submissions);
+}

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,11 @@
           "matches": ["*://*.codeforces.com/*/my"],
           "run_at": "document_idle",
           "js": ["codeforces.js"]
+        },
+        {
+          "matches": ["*://beta.atcoder.jp/contests/*/submissions/me"],
+          "run_at": "document_idle",
+          "js": ["atcoder.js"]
         }
       ],
     "options_ui": {

--- a/script.js
+++ b/script.js
@@ -71,7 +71,11 @@ function handleMessage(request, sender, sendResponse) {
     var time = request.time;
     var mem = request.mem;
     var id = request.id;
+    var score = request.score;
     var details = "Time taken " + time + "\nMemory used " + mem;
+    if (typeof score != 'undefined') {
+        details += "\nScore " + score;
+    }
     browser.storage.sync.get({
       sound: 'tts',
       type: 'all'

--- a/script.js
+++ b/script.js
@@ -72,10 +72,11 @@ function handleMessage(request, sender, sendResponse) {
     var mem = request.mem;
     var id = request.id;
     var score = request.score;
-    var details = "Time taken " + time + "\nMemory used " + mem;
-    if (typeof score != 'undefined') {
-        details += "\nScore " + score;
-    }
+    var details = []
+    if (typeof time != 'undefined') details.push("Time taken " + time);
+    if (typeof mem != 'undefined') details.push("Memory used " + mem);
+    if (typeof score != 'undefined') details.push("\nScore " + score);
+    details = details.join("\n");
     browser.storage.sync.get({
       sound: 'tts',
       type: 'all'


### PR DESCRIPTION
Support for AtCoder. I've opted to go for beta only, since it has a JSON API for updating the status. The JSON API returns the response as a HTML, which still needs to be parsed, but it is still simpler than parsing the entire page. Raised the refresh limit to 500ms, as I want to be courteous to the AtCoder servers.

Tested in Chrome 69.0.3497.100.